### PR TITLE
Cleanup and use config.boot instead

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,16 @@
+- name: copy config.boot
+  fetch: src=/config/config.boot
+         dest=configs/{{ inventory_hostname }}.config
+         flat=yes
+  register: copy_vyos_config_result
+
 - name: generate current config set
   shell: /opt/vyatta/sbin/vyatta-config-gen-sets.pl > /tmp/gen-sets
+  when: copy_vyos_config_result.changed==true
 
 - name: copy file gen-sets
   fetch: src=/tmp/gen-sets
          dest=configs/{{ inventory_hostname }}.gen-sets
-         flat=yes
-
-- name: copy config.boot
-  fetch: src=/config/config.boot
-         dest=configs/{{ inventory_hostname }}.config
          flat=yes
 
 - name: delete conf files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,5 +14,6 @@
          flat=yes
 
 - name: delete conf files
-  command: /bin/rm -f /tmp/gen-sets /tmp/config
+  file: path=/tmp/gen-sets
+        state=absent
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,13 @@
 - name: generate current config set
   shell: /opt/vyatta/sbin/vyatta-config-gen-sets.pl > /tmp/gen-sets
 
-- name: generate current config.
-  shell: /opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show > /tmp/config
-
 - name: copy file gen-sets
   fetch: src=/tmp/gen-sets
          dest=configs/{{ inventory_hostname }}.gen-sets
          flat=yes
 
-- name: copy file
-  fetch: src=/tmp/config
+- name: copy config.boot
+  fetch: src=/config/config.boot
          dest=configs/{{ inventory_hostname }}.config
          flat=yes
 


### PR DESCRIPTION
Hi Hiroyuki, Thanks for putting this role together.

I made a few changes for my use, hopefully you find them helpful:
- I've had problems using an old Vyatta config on a newer Vyos, but it worked ok when I took the config.boot file from the drive (preserving the version info).  So I switched to using this method to make old backups more useful.
- I made the get-sets tasks only run when the config has changed.  Now none of the tasks show as changed in Ansible unless there's actually been changes to the router config.
- I changed the delete command to use the file module instead of command.

All of these changes work across the routers I have access to, hope they work well for you too.
